### PR TITLE
Use APNs Provider API with HTTP/2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'puma'
 gem 'sinatra'
 gem 'sinatra-initializers'
-gem 'houston', "2.2.0"
+gem 'lowdown'
 gem 'foreman'
 gem 'rake'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,39 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    commander (4.3.4)
-      highline (~> 1.7.2)
+    celluloid (0.17.3)
+      celluloid-essentials
+      celluloid-extras
+      celluloid-fsm
+      celluloid-pool
+      celluloid-supervision
+      timers (>= 4.1.1)
+    celluloid-essentials (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-extras (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-fsm (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-io (0.17.3)
+      celluloid (>= 0.17.2)
+      nio4r (>= 1.1)
+      timers (>= 4.1.1)
+    celluloid-pool (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-supervision (0.20.6)
+      timers (>= 4.1.1)
     dotenv (0.11.1)
       dotenv-deployment (~> 0.0.2)
     dotenv-deployment (0.0.2)
     foreman (0.74.0)
       dotenv (~> 0.11.1)
       thor (~> 0.19.1)
-    highline (1.7.2)
-    houston (2.2.0)
-      commander (~> 4.1)
-      json
-    json (1.8.2)
+    hitimes (1.2.4)
+    http-2 (0.8.2)
+    lowdown (1.0.0)
+      celluloid-io (>= 0.17.3)
+      http-2 (>= 0.8)
+    nio4r (1.2.1)
     puma (3.6.0)
     rack (1.6.4)
     rack-protection (1.5.3)
@@ -26,13 +46,15 @@ GEM
     sinatra-initializers (0.1.4)
     thor (0.19.1)
     tilt (1.4.1)
+    timers (4.1.1)
+      hitimes
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   foreman
-  houston (= 2.2.0)
+  lowdown
   puma
   rake
   sinatra

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,9 +14,8 @@ GEM
       commander (~> 4.1)
       json
     json (1.8.2)
-    puma (2.8.2)
-      rack (>= 1.1, < 2.0)
-    rack (1.5.2)
+    puma (3.6.0)
+    rack (1.6.4)
     rack-protection (1.5.3)
       rack
     rake (0.9.6)
@@ -38,3 +37,6 @@ DEPENDENCIES
   rake
   sinatra
   sinatra-initializers
+
+BUNDLED WITH
+   1.13.0

--- a/push_it.rb
+++ b/push_it.rb
@@ -55,7 +55,6 @@ class PushIt < Sinatra::Base
         client.connect do |group|
           notifications.each do |notification|
             group.send_notification(notification) do |response|
-              p response
             end
           end
         end

--- a/push_it.rb
+++ b/push_it.rb
@@ -42,7 +42,7 @@ class PushIt < Sinatra::Base
 
     begin
       notifications = tokens.collect do |token|
-        notification = Lowdown::Notification.new(token: token, payload: { alert: alert, badge: badge, sound: sound })
+        notification = Lowdown::Notification.new(token: token.gsub(/[< >]/, ''), payload: { alert: alert, badge: badge, sound: sound })
         notification.payload["category"] = category if category
         notification.expiration = expiry if expiry
         notification.id = id if id


### PR DESCRIPTION
Apple now open APNs Provider API. When connecting via HTTP/2, providers can use only one push certificate for both development and production.

https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/APNsProviderAPI.html
